### PR TITLE
Adding The Kana Quiz app to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |--|--|--|
 |<img src="https://lh3.googleusercontent.com/lL4apRXXEY0c-zuiulfv7HwNqifLSGoqwTSsgkeLmse-SJG2ocI_glRfBCz3cvt9noiH=w300-rw" alt="AppOps" title="AppOps" width="50" height="50" />|[AppOps](https://play.google.com/store/apps/details?id=rikka.appops)|长得最好看的 appops 的 UI，还支持免 root 使用|
 |<img src="https://lh3.googleusercontent.com/ovUpC9kFZsdHVfbGVn64RR6y_IYCT2Z3vbkMjOxBDcp375Tecp8s6hi5aWTIvVs8Dg=w300-rw" alt="教务宝" title="教务宝" width="50" height="50" />|[教务宝](https://play.google.com/store/apps/details?id=com.sc_edu.jwb)|培训机构专属的教务管理系统，让教务管理更简单！|
+|<img src="https://github.com/theblackwidower/KanaQuiz/raw/develop/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png" alt="KanaQuiz" title="KanaQuiz" width="50" height="50" />|[The Kana Quiz](https://play.google.com/store/apps/details?id=com.noprestige.kanaquiz)|Multi-featured app to quiz the user on Japanese Kana, Kanji and Vocabulary|
 
 如果你的应用已支持 Font Provider，可以通过 pull request 来加入上面的列表。
 


### PR DESCRIPTION
My app, The Kana Quiz, as of version 0.14, now utilizes the Font Provider app for serifed Japanese characters. So I thought you may want to add it to the list of supported apps on the readme. I'm sorry it's not in Chinese, but I don't actually know any Chinese.